### PR TITLE
Add microlux to exoplanets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ implementation of many features from the
     - Paper: [arXiv:2409.00167](https://arxiv.org/abs/2409.00167)
 - [ExoJAX](https://github.com/HajimeKawahara/exojax) - differentiable spectrum model from exoplanet and substellar atmosphere <img src="https://img.shields.io/github/stars/HajimeKawahara/exojax?style=social" align="center">
     - Papers: [arXiv:2105.14782](https://arxiv.org/abs/2105.14782), [arXiv:2410.06900](https://arxiv.org/abs/2410.06900)
+- [microlux](https://github.com/CoastEgo/microlux) - A differentiable microlensing model using adaptive contour integration method <img src="https://img.shields.io/github/stars/CoastEgo/microlux?style=social" align="center">
+    - Paper: [arXiv:2501.07268](https://arxiv.org/abs/2501.07268)
 
 <a name="optics" />
 


### PR DESCRIPTION
Hello!

I want to add my code [microlux](https://github.com/CoastEgo/microlux), which is a JAX-based binary microlensing model with adaptive contour integration method.

The paper is published in [AJ](https://iopscience.iop.org/article/10.3847/1538-3881/adb1b2)

Thank you for considering this addition. 