### PR TITLE
Adding in astroemu under tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For a broader list of JAX resources, check out the [awesome-jax](https://github.
 
 ## Useful tools
 
-- 
+- [astroemu](https://github.com/htjb/astroemu) - Generalized framework for emulation of spectral data based on the tiling approach in [globalemu](https://arxiv.org/abs/2104.04336).
 
 <a name="inference" />
 


### PR DESCRIPTION
Adding `astroemu` into the list under tools. This is a framework for emulating spectral data using the tiling trick in the [globalemu](https://arxiv.org/abs/2104.04336). The idea is to input the independent variable (e.g. redshift, frequency, wavelength etc) in to the network alongside the astrophysical or cosmological parameters and predict a single corresponding spectral value. Then use a vectorised call to predict a full spectrum.
